### PR TITLE
Duplicate unzip command

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,6 @@ layout: reference
  $ wget http://sample.com/project.2010-06-01.zip
  $ unzip project.2010-06-01.zip
  $ cp -R project.2010-06-01 project-my-copy
- $ unzip project.2010-06-01.zip
  $ cd project-my-copy
  $ (change something)
  $ diff project-my-copy project.2010-06-01 > change.patch


### PR DESCRIPTION
Fixed an error in the index page, where there is a duplicate unzip command.
