### PR TITLE
Note about ^ for windows command-line users and a typo fix.

### DIFF
--- a/branching/index.html
+++ b/branching/index.html
@@ -665,6 +665,9 @@ b7ae93b added from ruby
       front of the branch that we don't want to see.  For instance, if we want
       to see the commits that are in the 'erlang' branch that are not in the
       'master' branch, we can do <code>erlang ^master</code>, or vice versa.
+      Note that the Windows command-line treats <code>^</code> as a special
+      character, in which case you'll need to surround <code>^master</code>
+      in quotes.
     </p>
 
 <pre>

--- a/remotes/index.html
+++ b/remotes/index.html
@@ -94,7 +94,7 @@ origin	git@github.com:schacon/git-reference.git (push)
     </h4>
 
     <p>If you want to share a locally created repository, or you want to take
-    contributions from someone elses repository - if you want to interact in
+    contributions from someone else's repository - if you want to interact in
     any way with a new repository, it's generally easiest to add it as a remote.
     You do that by running <code>git remote add [alias] [url]</code>.  That
     adds <code>[url]</code> under a local remote named <code>[alias]</code>.</p>


### PR DESCRIPTION
Two small changes here.  I don't know for sure if you'll want the first one.  It's a windows-specific note because I got tripped up when trying to follow the examples because Windows treats ^ as a special character.  The second is a simple typo fix of "elses" to "else's".

Note: This is my first attempt at git so let me know if I screwed anything up. :-)

Also, www.gitref.org was really helpful.  Thanks for creating it!
