### PR TITLE
Replace broken links to kernel.org

### DIFF
--- a/basic/index.html
+++ b/basic/index.html
@@ -38,7 +38,7 @@ layout: reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">docs</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-add.html">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-2.html#tracking_new_files">book</a>
     </span>
     <a name="add">git add</a>
@@ -130,7 +130,7 @@ layout: reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-status.html">docs</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-status.html">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-2.html#checking_the_status_of_your_files">book</a>
     </span>
     <a name="status">git status</a>
@@ -214,7 +214,7 @@ layout: reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-diff.html">docs</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-diff.html">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-2.html#viewing_your_staged_and_unstaged_changes">book</a>
     </span>
     <a name="diff">git diff</a>
@@ -416,7 +416,7 @@ index 2aabb6e..2ae9ba4 100644
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">docs</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-commit.html">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-2.html#committing_your_changes">book</a>
     </span>
     <a name="commit">git commit</a>
@@ -596,7 +596,7 @@ Further paragraphs come after blank lines.
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-reset.html">docs</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-reset.html">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-4.html#unstaging_a_staged_file">book</a>
     </span>
     <a name="reset">git reset HEAD</a>
@@ -694,7 +694,7 @@ M hello.rb
 <div class="box">
   <h2>
     <span class="docs">
-      <a href="http://www.kernel.org/pub/software/scm/git/docs/git-rm.html">docs</a> &nbsp;
+      <a href="http://schacon.github.com/git/git-rm.html">docs</a> &nbsp;
       <a href="http://progit.org/book/ch2-2.html#removing_files">book</a>
     </span>
     <a name="rm-mv">git rm</a>

--- a/branching/index.html
+++ b/branching/index.html
@@ -38,7 +38,7 @@ layout: reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-branch.html">docs</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-branch.html">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch3-2.html">book</a>
     </span>
     <a name="branch">git branch</a>
@@ -49,7 +49,7 @@ layout: reference
 
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-checkout.html">docs</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-checkout.html">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch3-2.html">book</a>
     </span>
     <a name="checkout">git checkout</a>
@@ -226,7 +226,7 @@ Deleted branch testing (was 78b2670).
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-merge.html">docs</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-merge.html">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch3-2.html#basic_merging">book</a>
     </span>
     <a name="merge">git merge</a>
@@ -421,7 +421,7 @@ nearly every programming language.
     <p>You can see that Git inserts standard merge conflict markers, much like
       Subversion, into files when it gets a merge conflict.  Now it's up to us
       to resolve them.  We will do it manually here, but check out
-      <a href="http://www.kernel.org/pub/software/scm/git/docs/git-mergetool.html">git mergetool</a>
+      <a href="http://schacon.github.com/git/git-mergetool.html">git mergetool</a>
       if you want Git to fire up a graphical mergetool
       (like kdiff3, emerge, p4merge, etc) instead.
     </p>
@@ -473,7 +473,7 @@ M  README
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">docs</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-log.html">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch6-1.html#commit_ranges">book</a>
     </span>
     <a name="log">git log</a>
@@ -693,7 +693,7 @@ ab5ab4c added erlang
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-tag.html">docs</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-tag.html">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-6.html">book</a>
     </span>
     <a name="tag">git tag</a>

--- a/creating/index.html
+++ b/creating/index.html
@@ -23,7 +23,7 @@ layout: reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-init.html">docs</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-init.html">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-1.html#initializing_a_repository_in_an_existing_directory">book</a>
     </span>
     <a name="init">git init</a>
@@ -74,7 +74,7 @@ Initialized empty Git repository in /opt/konichiwa/.git/
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-clone.html">docs</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-clone.html">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-1.html#cloning_an_existing_repository">book</a>
     </span>
     <a name="clone">git clone</a>

--- a/inspect/index.html
+++ b/inspect/index.html
@@ -30,7 +30,7 @@ layout: reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">docs</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-log.html">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-3.html">book</a>
     </span>
     <a name="log">git log</a>
@@ -309,7 +309,7 @@ Date:   Fri Jun 4 12:58:53 2010 +0200
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-diff.html">docs</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-diff.html">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch5-3.html#determining_what_is_introduced">book</a>
     </span>
     <a name="diff">git diff</a>

--- a/remotes/index.html
+++ b/remotes/index.html
@@ -43,7 +43,7 @@ layout: reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-remote.html">docs</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-remote.html">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-5.html#showing_your_remotes">book</a>
     </span>
     <a name="remote">git remote</a>
@@ -159,7 +159,7 @@ github	git@github.com:schacon/hw.git (push)
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-fetch.html">docs</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-fetch.html">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-5.html#fetching_and_pulling_from_your_remotes">book</a>
     </span>
     <a name="fetch">git fetch</a>
@@ -170,7 +170,7 @@ github	git@github.com:schacon/hw.git (push)
 
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-pull.html">docs</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-pull.html">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/">book</a>
     </span>
     <a name="pull">git pull</a>
@@ -195,7 +195,7 @@ github	git@github.com:schacon/hw.git (push)
     like this command - I prefer running <code>fetch</code> and <code>merge</code>
     separately.  Less magic, less problems.  However, if you like this idea, you
     can read about it in more detail in the
-    <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-pull.html">official docs</a>.
+    <a target="new" href="http://schacon.github.com/git/git-pull.html">official docs</a>.
     </p>
 
     <p>Assuming you have a remote all set up and you want to pull in updates, you
@@ -254,7 +254,7 @@ From github.com:schacon/hw
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">docs</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-push.html">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-5.html#pushing_to_your_remotes">book</a>
     </span>
     <a name="push">git push</a>

--- a/zh/basic/index.html
+++ b/zh/basic/index.html
@@ -28,7 +28,7 @@ layout: zh_reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">文档</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-add.html">文档</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-2.html#tracking_new_files">书</a>
     </span>
     <a name="add">git add</a>
@@ -94,7 +94,7 @@ layout: zh_reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-status.html">文档</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-status.html">文档</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-2.html#checking_the_status_of_your_files">书</a>
     </span>
     <a name="status">git status</a>
@@ -162,7 +162,7 @@ layout: zh_reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-diff.html">文档</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-diff.html">文档</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-2.html#viewing_your_staged_and_unstaged_changes">书</a>
     </span>
     <a name="diff">git diff</a>
@@ -337,7 +337,7 @@ index 2aabb6e..2ae9ba4 100644
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">文档</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-commit.html">文档</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-2.html#committing_your_changes">书</a>
     </span>
     <a name="commit">git commit</a>
@@ -475,7 +475,7 @@ nothing to commit (working directory clean)
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-reset.html">文档</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-reset.html">文档</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-4.html#unstaging_a_staged_file">书</a>
     </span>
     <a name="reset">git reset HEAD</a>
@@ -544,7 +544,7 @@ M hello.rb
 <div class="box">
   <h2>
     <span class="docs">
-      <a href="http://www.kernel.org/pub/software/scm/git/docs/git-rm.html">文档</a> &nbsp;
+      <a href="http://schacon.github.com/git/git-rm.html">文档</a> &nbsp;
       <a href="http://progit.org/book/ch2-2.html#removing_files">书</a>
     </span>
     <a name="rm-mv">git rm</a>

--- a/zh/branching/index.html
+++ b/zh/branching/index.html
@@ -23,7 +23,7 @@ layout: zh_reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-branch.html">文档</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-branch.html">文档</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch3-2.html">书</a>
     </span>
     <a name="branch">git branch</a>
@@ -34,7 +34,7 @@ layout: zh_reference
 
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-checkout.html">文档</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-checkout.html">文档</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch3-2.html">书</a>
     </span>
     <a name="checkout">git checkout</a>
@@ -176,7 +176,7 @@ Deleted branch testing (was 78b2670).
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-merge.html">docs</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-merge.html">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch3-2.html#basic_merging">book</a>
     </span>
     <a name="merge">git merge</a>
@@ -342,7 +342,7 @@ This project has examples of hello world in
 nearly every programming language.
 </pre>
 
-    <p>您可以看到，Git 在产生合并冲突的地方插入了标准的与 Subversion 很像的合并冲突标记。轮到我们去解决这些冲突了。在这里我们就手动把它解决。如果您要 Git 打开一个图形化的合并工具，可以看看 <a href="http://www.kernel.org/pub/software/scm/git/docs/git-mergetool.html">git 合并工具</a>（比如 kdiff3、emerge、p4merge 等）。
+    <p>您可以看到，Git 在产生合并冲突的地方插入了标准的与 Subversion 很像的合并冲突标记。轮到我们去解决这些冲突了。在这里我们就手动把它解决。如果您要 Git 打开一个图形化的合并工具，可以看看 <a href="http://schacon.github.com/git/git-mergetool.html">git 合并工具</a>（比如 kdiff3、emerge、p4merge 等）。
     </p>
 
 <pre>
@@ -386,7 +386,7 @@ M  README
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">文档</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-log.html">文档</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch6-1.html#commit_ranges">书</a>
     </span>
     <a name="log">git log</a>
@@ -560,7 +560,7 @@ ab5ab4c added erlang
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-tag.html">文档</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-tag.html">文档</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-6.html">书</a>
     </span>
     <a name="tag">git tag</a>

--- a/zh/creating/index.html
+++ b/zh/creating/index.html
@@ -18,7 +18,7 @@ layout: zh_reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-init.html">文档</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-init.html">文档</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-1.html#initializing_a_repository_in_an_existing_directory">书</a>
     </span>
     <a name="init">git init</a>
@@ -60,7 +60,7 @@ Initialized empty Git repository in /opt/konichiwa/.git/
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-clone.html">文档 </a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-clone.html">文档 </a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-1.html#cloning_an_existing_repository">书</a>
     </span>
     <a name="clone">git clone</a>

--- a/zh/inspect/index.html
+++ b/zh/inspect/index.html
@@ -23,7 +23,7 @@ layout: zh_reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">文档</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-log.html">文档</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-3.html">书k</a>
     </span>
     <a name="log">git log</a>
@@ -268,7 +268,7 @@ Date:   Fri Jun 4 12:58:53 2010 +0200
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-diff.html">文档</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-diff.html">文档</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch5-3.html#determining_what_is_introduced">书</a>
     </span>
     <a name="diff">git diff</a>

--- a/zh/remotes/index.html
+++ b/zh/remotes/index.html
@@ -31,7 +31,7 @@ layout: zh_reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-remote.html">文档</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-remote.html">文档</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-5.html#showing_your_remotes">书</a>
     </span>
     <a name="remote">git remote</a>
@@ -127,7 +127,7 @@ github	git@github.com:schacon/hw.git (push)
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-fetch.html">文档</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-fetch.html">文档</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-5.html#fetching_and_pulling_from_your_remotes">书</a>
     </span>
     <a name="fetch">git fetch</a>
@@ -138,7 +138,7 @@ github	git@github.com:schacon/hw.git (push)
 
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-pull.html">文档</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-pull.html">文档</a> &nbsp;
       <a target="new" href="http://progit.org/book/">书</a>
     </span>
     <a name="pull">git pull</a>
@@ -152,7 +152,7 @@ github	git@github.com:schacon/hw.git (push)
     </p>
 
     <p>
-    第二个会从远端服务器提取新数据的命令是 <code>git pull</code>。基本上，该命令就是在 <code>git fetch</code> 之后紧接着 <code>git merge</code> 远端分支到您所在的任意分支。我个人不太喜欢这命令 —— 我更喜欢 <code>fetch</code> 和 <code>merge</code> 分开来做。少点魔法，少点问题。不过，如果您喜欢这主意，您可以看一下 <code>git pull</code> 的 <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-pull.html">官方文档</a>。
+    第二个会从远端服务器提取新数据的命令是 <code>git pull</code>。基本上，该命令就是在 <code>git fetch</code> 之后紧接着 <code>git merge</code> 远端分支到您所在的任意分支。我个人不太喜欢这命令 —— 我更喜欢 <code>fetch</code> 和 <code>merge</code> 分开来做。少点魔法，少点问题。不过，如果您喜欢这主意，您可以看一下 <code>git pull</code> 的 <a target="new" href="http://schacon.github.com/git/git-pull.html">官方文档</a>。
     </p>
 
     <p>
@@ -196,7 +196,7 @@ From github.com:schacon/hw
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">文档</a> &nbsp;
+      <a target="new" href="http://schacon.github.com/git/git-push.html">文档</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-5.html#pushing_to_your_remotes">书</a>
     </span>
     <a name="push">git push</a>


### PR DESCRIPTION
Links to the man pages in kernel.org were broken. I replaced all of them with links to their new locations at http://schacon.github.com/git/.

This is what I did:

```
for file in $(grep 'kernel\.org' -R -l .)
do
    sed -e 's#www.kernel.org/pub/software/scm/git/docs/#schacon.github.com/git/#g' -i $file
done
```
