### PR TITLE
Fix documentation for git log --since --authored

### DIFF
--- a/inspect/index.html
+++ b/inspect/index.html
@@ -73,7 +73,7 @@ b532581 make "git unpack-file" a built-in
 
     <h4>
       git log --since --before
-      <small>filter commits by date authored</small>
+      <small>filter commits by date committed</small>
     </h4>
 
     <p>


### PR DESCRIPTION
"By default, “git log” displays author dates as “Date” but then uses commit
dates when given a –since option. That seems like broken defaults to me."
    - http://www.alexpeattie.com/blog/working-with-dates-in-git/

 filter commits by date authored

should be

 filter commits by date committed
