### PR TITLE
Fixed docs links to point to git-scm.com/docs

### DIFF
--- a/basic/index.html
+++ b/basic/index.html
@@ -38,7 +38,7 @@ layout: reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">docs</a> &nbsp;
+      <a target="new" href="http://git-scm.com/docs/git-add">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-2.html#tracking_new_files">book</a>
     </span>
     <a name="add">git add</a>
@@ -130,7 +130,7 @@ layout: reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-status.html">docs</a> &nbsp;
+      <a target="new" href="http://git-scm.com/docs/git-status">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-2.html#checking_the_status_of_your_files">book</a>
     </span>
     <a name="status">git status</a>
@@ -214,7 +214,7 @@ layout: reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-diff.html">docs</a> &nbsp;
+      <a target="new" href="http://git-scm.com/docs/git-diff">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-2.html#viewing_your_staged_and_unstaged_changes">book</a>
     </span>
     <a name="diff">git diff</a>
@@ -416,7 +416,7 @@ index 2aabb6e..2ae9ba4 100644
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">docs</a> &nbsp;
+      <a target="new" href="http://git-scm.com/docs/git-commit">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-2.html#committing_your_changes">book</a>
     </span>
     <a name="commit">git commit</a>
@@ -596,7 +596,7 @@ Further paragraphs come after blank lines.
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-reset.html">docs</a> &nbsp;
+      <a target="new" href="http://git-scm.com/docs/git-reset">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-4.html#unstaging_a_staged_file">book</a>
     </span>
     <a name="reset">git reset HEAD</a>
@@ -694,7 +694,7 @@ M hello.rb
 <div class="box">
   <h2>
     <span class="docs">
-      <a href="http://www.kernel.org/pub/software/scm/git/docs/git-rm.html">docs</a> &nbsp;
+      <a href="http://git-scm.com/docs/git-rm">docs</a> &nbsp;
       <a href="http://progit.org/book/ch2-2.html#removing_files">book</a>
     </span>
     <a name="rm-mv">git rm</a>

--- a/branching/index.html
+++ b/branching/index.html
@@ -38,7 +38,7 @@ layout: reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-branch.html">docs</a> &nbsp;
+      <a target="new" href="http://git-scm.com/docs/git-branch">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch3-2.html">book</a>
     </span>
     <a name="branch">git branch</a>
@@ -49,7 +49,7 @@ layout: reference
 
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-checkout.html">docs</a> &nbsp;
+      <a target="new" href="http://git-scm.com/docs/git-checkout">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch3-2.html">book</a>
     </span>
     <a name="checkout">git checkout</a>
@@ -226,7 +226,7 @@ Deleted branch testing (was 78b2670).
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-merge.html">docs</a> &nbsp;
+      <a target="new" href="http://git-scm.com/docs/git-merge">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch3-2.html#basic_merging">book</a>
     </span>
     <a name="merge">git merge</a>
@@ -421,7 +421,7 @@ nearly every programming language.
     <p>You can see that Git inserts standard merge conflict markers, much like
       Subversion, into files when it gets a merge conflict.  Now it's up to us
       to resolve them.  We will do it manually here, but check out
-      <a href="http://www.kernel.org/pub/software/scm/git/docs/git-mergetool.html">git mergetool</a>
+      <a href="http://git-scm.com/docs/git-mergetool">git mergetool</a>
       if you want Git to fire up a graphical mergetool
       (like kdiff3, emerge, p4merge, etc) instead.
     </p>
@@ -473,7 +473,7 @@ M  README
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">docs</a> &nbsp;
+      <a target="new" href="http://git-scm.com/docs/git-log">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch6-1.html#commit_ranges">book</a>
     </span>
     <a name="log">git log</a>
@@ -693,7 +693,7 @@ ab5ab4c added erlang
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-tag.html">docs</a> &nbsp;
+      <a target="new" href="http://git-scm.com/docs/git-tag">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-6.html">book</a>
     </span>
     <a name="tag">git tag</a>

--- a/creating/index.html
+++ b/creating/index.html
@@ -23,7 +23,7 @@ layout: reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-init.html">docs</a> &nbsp;
+      <a target="new" href="http://git-scm.com/docs/git-init">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-1.html#initializing_a_repository_in_an_existing_directory">book</a>
     </span>
     <a name="init">git init</a>
@@ -74,7 +74,7 @@ Initialized empty Git repository in /opt/konichiwa/.git/
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-clone.html">docs</a> &nbsp;
+      <a target="new" href="http://git-scm.com/docs/git-clone">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-1.html#cloning_an_existing_repository">book</a>
     </span>
     <a name="clone">git clone</a>

--- a/inspect/index.html
+++ b/inspect/index.html
@@ -30,7 +30,7 @@ layout: reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">docs</a> &nbsp;
+      <a target="new" href="http://git-scm.com/docs/git-log">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-3.html">book</a>
     </span>
     <a name="log">git log</a>
@@ -309,7 +309,7 @@ Date:   Fri Jun 4 12:58:53 2010 +0200
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-diff.html">docs</a> &nbsp;
+      <a target="new" href="http://git-scm.com/docs/git-diff">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch5-3.html#determining_what_is_introduced">book</a>
     </span>
     <a name="diff">git diff</a>

--- a/remotes/index.html
+++ b/remotes/index.html
@@ -43,7 +43,7 @@ layout: reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-remote.html">docs</a> &nbsp;
+      <a target="new" href="http://git-scm.com/docs/git-remote">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-5.html#showing_your_remotes">book</a>
     </span>
     <a name="remote">git remote</a>
@@ -159,7 +159,7 @@ github	git@github.com:schacon/hw.git (push)
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-fetch.html">docs</a> &nbsp;
+      <a target="new" href="http://git-scm.com/docs/git-fetch">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-5.html#fetching_and_pulling_from_your_remotes">book</a>
     </span>
     <a name="fetch">git fetch</a>
@@ -170,7 +170,7 @@ github	git@github.com:schacon/hw.git (push)
 
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-pull.html">docs</a> &nbsp;
+      <a target="new" href="http://git-scm.com/docs/git-pull">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/">book</a>
     </span>
     <a name="pull">git pull</a>
@@ -195,7 +195,7 @@ github	git@github.com:schacon/hw.git (push)
     like this command - I prefer running <code>fetch</code> and <code>merge</code>
     separately.  Less magic, less problems.  However, if you like this idea, you
     can read about it in more detail in the
-    <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-pull.html">official docs</a>.
+    <a target="new" href="http://git-scm.com/docs/git-pull">official docs</a>.
     </p>
 
     <p>Assuming you have a remote all set up and you want to pull in updates, you
@@ -254,7 +254,7 @@ From github.com:schacon/hw
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-push.html">docs</a> &nbsp;
+      <a target="new" href="http://git-scm.com/docs/git-push">docs</a> &nbsp;
       <a target="new" href="http://progit.org/book/ch2-5.html#pushing_to_your_remotes">book</a>
     </span>
     <a name="push">git push</a>


### PR DESCRIPTION
I fixed links in for the "docs" links on each of the pages to point to the new git webpage.
