### PR TITLE
Chevrons in Git outputs disappear if not encoded

### DIFF
--- a/basic/index.html
+++ b/basic/index.html
@@ -162,14 +162,14 @@ layout: reference
 # Initial commit
 #
 # Changes to be committed:
-#   (use "git rm --cached <file>..." to unstage)
+#   (use "git rm --cached &lt;file>..." to unstage)
 #
 # <span class="green">new file:   README</span>
 # <span class="green">new file:   hello.rb</span>
 #
 # Changed but not updated:
-#   (use "git add <file>..." to update what will be committed)
-#   (use "git checkout -- <file>..." to discard changes in working directory)
+#   (use "git add &lt;file>..." to update what will be committed)
+#   (use "git checkout -- &lt;file>..." to discard changes in working directory)
 #
 # <span class="red">modified:   README</span>
 #
@@ -474,7 +474,7 @@ nothing to commit (working directory clean)
 # with '#' will be ignored, and an empty message aborts the commit.
 # On branch master
 # Changes to be committed:
-#   (use "git reset HEAD <file>..." to unstage)
+#   (use "git reset HEAD &lt;file>..." to unstage)
 #
 # modified:   hello.rb
 #
@@ -514,7 +514,7 @@ Further paragraphs come after blank lines.
 # with '#' will be ignored, and an empty message aborts the commit.
 # On branch master
 # Changes to be committed:
-#   (use "git reset HEAD <file>..." to unstage)
+#   (use "git reset HEAD &lt;file>..." to unstage)
 #
 # modified:   hello.rb
 #
@@ -558,8 +558,8 @@ Further paragraphs come after blank lines.
 <b>$ git commit -m 'changes to hello file'</b>
 # On branch master
 # Changed but not updated:
-#   (use "git add <file>..." to update what will be committed)
-#   (use "git checkout -- <file>..." to discard changes in working directory)
+#   (use "git add &lt;file>..." to update what will be committed)
+#   (use "git checkout -- &lt;file>..." to discard changes in working directory)
 #
 # modified:   hello.rb
 #
@@ -680,7 +680,7 @@ M hello.rb
 <b>$ git status</b>
 # On branch master
 # Changes to be committed:
-#   <span class="hl">(use "git reset HEAD <file>..." to unstage)</span>
+#   <span class="hl">(use "git reset HEAD &lt;file>..." to unstage)</span>
 #
 #   <span class="green">modified:   README</span>
 #   <span class="green">modified:   hello.rb</span>
@@ -735,13 +735,13 @@ nothing to commit (working directory clean)
 <b>$ git status</b>
 # On branch master
 # Changes to be committed:
-#   (use "git reset HEAD <file>..." to unstage)
+#   (use "git reset HEAD &lt;file>..." to unstage)
 #
 # <span class="green">modified:   README</span>
 #
 # Changes not staged for commit:
-#   (use "git add <file>..." to update what will be committed)
-#   (use "git checkout -- <file>..." to discard changes in working directory)
+#   (use "git add &lt;file>..." to update what will be committed)
+#   (use "git checkout -- &lt;file>..." to discard changes in working directory)
 #
 # <span class="red">modified:   README</span>
 #

--- a/inspect/index.html
+++ b/inspect/index.html
@@ -123,8 +123,8 @@ Date:   Wed Mar 12 19:03:24 2008 -0500
     preferred editor for use in perforce.  Since we are displaying a
     perforce changelog to the user we should use it when it is defined.
 
-    Signed-off-by: Shawn Bohrer <shawn.bohrer@gmail.com>
-    Signed-off-by: Simon Hausmann <simon@lst.de>
+    Signed-off-by: Shawn Bohrer &lt;shawn.bohrer@gmail.com>
+    Signed-off-by: Simon Hausmann &lt;simon@lst.de>
 </pre>
 
     <p>
@@ -229,7 +229,7 @@ Date:   Tue Apr 13 22:31:12 2010 +0200
 <pre>
 <b>$ git log -p --no-merges -2</b>
 <span class="yellow">commit 594f90bdee4faf063ad07a4a6f503fdead3ef606</span>
-Author: Scott Chacon schacon@gmail.com
+Author: Scott Chacon &lt;schacon@gmail.com>
 Date:   Fri Jun 4 15:46:55 2010 +0200
 
     reverted to old class name
@@ -250,7 +250,7 @@ index bb86f00..192151c 100644
 <span class="green">+HelloWorld.hello</span>
 
 <span class="yellow">commit 3cbb6aae5c0cbd711c098e113ae436801371c95e</span>
-Author: Scott Chacon schacon@gmail.com
+Author: Scott Chacon &lt;schacon@gmail.com>
 Date:   Fri Jun 4 12:58:53 2010 +0200
 
     fixed readme title differently
@@ -282,7 +282,7 @@ index d053cc8..9103e27 100644
 <pre>
 <b>$ git log --stat --no-merges -2</b>
 <span class="yellow">commit 594f90bdee4faf063ad07a4a6f503fdead3ef606</span>
-Author: Scott Chacon schacon@gmail.com
+Author: Scott Chacon &lt;schacon@gmail.com>
 Date:   Fri Jun 4 15:46:55 2010 +0200
 
     reverted to old class name
@@ -291,7 +291,7 @@ Date:   Fri Jun 4 15:46:55 2010 +0200
  1 files changed, 2 insertions(+), 2 deletions(-)
 
 <span class="yellow">commit 3cbb6aae5c0cbd711c098e113ae436801371c95e</span>
-Author: Scott Chacon schacon@gmail.com
+Author: Scott Chacon &lt;schacon@gmail.com>
 Date:   Fri Jun 4 12:58:53 2010 +0200
 
     fixed readme title differently

--- a/zh/basic/index.html
+++ b/zh/basic/index.html
@@ -134,14 +134,14 @@ layout: zh_reference
 # Initial commit
 #
 # Changes to be committed:
-#   (use "git rm --cached <file>..." to unstage)
+#   (use "git rm --cached &lt;file>..." to unstage)
 #
 # <span class="green">new file:   README</span>
 # <span class="green">new file:   hello.rb</span>
 #
 # Changed but not updated:
-#   (use "git add <file>..." to update what will be committed)
-#   (use "git checkout -- <file>..." to discard changes in working directory)
+#   (use "git add &lt;file>..." to update what will be committed)
+#   (use "git checkout -- &lt;file>..." to discard changes in working directory)
 #
 # <span class="red">modified:   README</span>
 #
@@ -415,7 +415,7 @@ nothing to commit (working directory clean)
 # with '#' will be ignored, and an empty message aborts the commit.
 # On branch master
 # Changes to be committed:
-#   (use "git reset HEAD <file>..." to unstage)
+#   (use "git reset HEAD &lt;file>..." to unstage)
 #
 # modified:   hello.rb
 #
@@ -449,7 +449,7 @@ nothing to commit (working directory clean)
 # with '#' will be ignored, and an empty message aborts the commit.
 # On branch master
 # Changes to be committed:
-#   (use "git reset HEAD <file>..." to unstage)
+#   (use "git reset HEAD &lt;file>..." to unstage)
 #
 # modified:   hello.rb
 #
@@ -485,8 +485,8 @@ nothing to commit (working directory clean)
 <b>$ git commit -m 'changes to hello file'</b>
 # On branch master
 # Changed but not updated:
-#   (use "git add <file>..." to update what will be committed)
-#   (use "git checkout -- <file>..." to discard changes in working directory)
+#   (use "git add &lt;file>..." to update what will be committed)
+#   (use "git checkout -- &lt;file>..." to discard changes in working directory)
 #
 # modified:   hello.rb
 #
@@ -578,7 +578,7 @@ M hello.rb
 <b>$ git status</b>
 # On branch master
 # Changes to be committed:
-#   <span class="hl">(use "git reset HEAD <file>..." to unstage)</span>
+#   <span class="hl">(use "git reset HEAD &lt;file>..." to unstage)</span>
 #
 #   <span class="green">modified:   README</span>
 #   <span class="green">modified:   hello.rb</span>

--- a/zh/inspect/index.html
+++ b/zh/inspect/index.html
@@ -110,8 +110,8 @@ Date:   Wed Mar 12 19:03:24 2008 -0500
     preferred editor for use in perforce.  Since we are displaying a
     perforce changelog to the user we should use it when it is defined.
 
-    Signed-off-by: Shawn Bohrer <shawn.bohrer@gmail.com>
-    Signed-off-by: Simon Hausmann <simon@lst.de>
+    Signed-off-by: Shawn Bohrer &lt;shawn.bohrer@gmail.com>
+    Signed-off-by: Simon Hausmann &lt;simon@lst.de>
 </pre>
 
     <p>
@@ -210,7 +210,7 @@ Date:   Tue Apr 13 22:31:12 2010 +0200
 <pre>
 <b>$ git log -p --no-merges -2</b>
 <span class="yellow">commit 594f90bdee4faf063ad07a4a6f503fdead3ef606</span>
-Author: Scott Chacon schacon@gmail.com
+Author: Scott Chacon &lt;schacon@gmail.com>
 Date:   Fri Jun 4 15:46:55 2010 +0200
 
     reverted to old class name
@@ -231,7 +231,7 @@ index bb86f00..192151c 100644
 <span class="green">+HelloWorld.hello</span>
 
 <span class="yellow">commit 3cbb6aae5c0cbd711c098e113ae436801371c95e</span>
-Author: Scott Chacon schacon@gmail.com
+Author: Scott Chacon &lt;schacon@gmail.com>
 Date:   Fri Jun 4 12:58:53 2010 +0200
 
     fixed readme title differently
@@ -265,7 +265,7 @@ index d053cc8..9103e27 100644
 <pre>
 <b>$ git log --stat --no-merges -2</b>
 <span class="yellow">commit 594f90bdee4faf063ad07a4a6f503fdead3ef606</span>
-Author: Scott Chacon schacon@gmail.com
+Author: Scott Chacon &lt;schacon@gmail.com>
 Date:   Fri Jun 4 15:46:55 2010 +0200
 
     reverted to old class name
@@ -274,7 +274,7 @@ Date:   Fri Jun 4 15:46:55 2010 +0200
  1 files changed, 2 insertions(+), 2 deletions(-)
 
 <span class="yellow">commit 3cbb6aae5c0cbd711c098e113ae436801371c95e</span>
-Author: Scott Chacon schacon@gmail.com
+Author: Scott Chacon &lt;schacon@gmail.com>
 Date:   Fri Jun 4 12:58:53 2010 +0200
 
     fixed readme title differently


### PR DESCRIPTION
Also added some in to be consistent with expected output
when `git log` is run to show author email addresses inside such.
