### PR TITLE
Update progit and kernel links to git-scm in Chinese translation

### DIFF
--- a/_layouts/reference.html
+++ b/_layouts/reference.html
@@ -27,7 +27,7 @@
           <!-- <li><a id="menu_cookbook" href="/cookbook.html">Cookbook</a></li> -->
 					<li><a id="menu_about" href="/about.html">About</a></li>
 					<li>&#167;</li>
-					<li><a href="http://github.com/github/git-reference">Site Source</a></li>
+					<li><a href="https://github.com/github/git-reference">Site Source</a></li>
         </ul>
         <br/>
         &nbsp;

--- a/_layouts/zh_reference.html
+++ b/_layouts/zh_reference.html
@@ -27,7 +27,7 @@
           <!-- <li><a id="menu_cookbook" href="/zh/cookbook.html">Cookbook</a></li> -->
 					<li><a id="menu_about" href="/zh/about.html">关于</a></li>
 					<li>&#167;</li>
-					<li><a href="http://github.com/github/git-reference">网站源码</a></li>
+					<li><a href="https://github.com/github/git-reference">网站源码</a></li>
         </ul>
         <br/>
         &nbsp;

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@ layout: reference
     </p>
 
     <pre>
- $ wget http://sample.com/project.2010-06-01.zip
+ $ wget http://example.com/project.2010-06-01.zip
  $ unzip project.2010-06-01.zip
  $ cp -R project.2010-06-01 project-my-copy
  $ cd project-my-copy

--- a/zh/basic/index.html
+++ b/zh/basic/index.html
@@ -5,7 +5,7 @@ layout: zh_reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://progit.org/book/ch2-2.html">书</a>
+      <a target="new" href="http://git-scm.com/book/en/Git-Basics-Recording-Changes-to-the-Repository">书</a>
     </span>
     基本快照
   </h2>
@@ -30,8 +30,8 @@ layout: zh_reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-add.html">文档</a> &nbsp;
-      <a target="new" href="http://progit.org/book/ch2-2.html#tracking_new_files">书</a>
+      <a target="new" href="http://git-scm.com/docs/git-add">文档</a> &nbsp;
+      <a target="new" href="http://git-scm.com/book/en/Git-Basics-Recording-Changes-to-the-Repository#Tracking-New-Files">书</a>
     </span>
     <a name="add">git add</a>
     <span class="desc">添加文件到缓存</span>
@@ -105,8 +105,8 @@ layout: zh_reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-status.html">文档</a> &nbsp;
-      <a target="new" href="http://progit.org/book/ch2-2.html#checking_the_status_of_your_files">书</a>
+      <a target="new" href="http://git-scm.com/docs/git-status">文档</a> &nbsp;
+      <a target="new" href="http://git-scm.com/book/en/Git-Basics-Recording-Changes-to-the-Repository#Checking-the-Status-of-Your-Files">书</a>
     </span>
     <a name="status">git status</a>
     <span class="desc">查看你的文件在工作目录与缓存的状态</span>
@@ -178,8 +178,8 @@ layout: zh_reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-diff.html">文档</a> &nbsp;
-      <a target="new" href="http://progit.org/book/ch2-2.html#viewing_your_staged_and_unstaged_changes">书</a>
+      <a target="new" href="http://git-scm.com/docs/git-diff">文档</a> &nbsp;
+      <a target="new" href="http://git-scm.com/book/en/Git-Basics-Recording-Changes-to-the-Repository#Viewing-Your-Staged-and-Unstaged-Changes">书</a>
     </span>
     <a name="diff">git diff</a>
     <span class="desc">显示已写入缓存与已修改但尚未写入缓存的改动的区别</span>
@@ -364,8 +364,8 @@ index 2aabb6e..2ae9ba4 100644
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-commit.html">文档</a> &nbsp;
-      <a target="new" href="http://progit.org/book/ch2-2.html#committing_your_changes">书</a>
+      <a target="new" href="http://git-scm.com/docs/git-commit">文档</a> &nbsp;
+      <a target="new" href="http://git-scm.com/book/en/Git-Basics-Recording-Changes-to-the-Repository#Committing-Your-Changes">书</a>
     </span>
     <a name="commit">git commit</a>
     <span class="desc">记录缓存内容的快照</span>
@@ -516,8 +516,8 @@ nothing to commit (working directory clean)
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-reset.html">文档</a> &nbsp;
-      <a target="new" href="http://progit.org/book/ch2-4.html#unstaging_a_staged_file">书</a>
+      <a target="new" href="http://git-scm.com/docs/git-reset">文档</a> &nbsp;
+      <a target="new" href="http://git-scm.com/book/en/Git-Basics-Undoing-Things#Unstaging-a-Staged-File">书</a>
     </span>
     <a name="reset">git reset HEAD</a>
     <span class="desc">取消缓存已缓存的内容</span>
@@ -595,8 +595,8 @@ M hello.rb
 <div class="box">
   <h2>
     <span class="docs">
-      <a href="http://www.kernel.org/pub/software/scm/git/docs/git-rm.html">文档</a> &nbsp;
-      <a href="http://progit.org/book/ch2-2.html#removing_files">书</a>
+      <a href="http://git-scm.com/docs/git-rm">文档</a> &nbsp;
+      <a href="http://git-scm.com/book/en/Git-Basics-Recording-Changes-to-the-Repository#Removing-Files">书</a>
     </span>
     <a name="rm-mv">git rm</a>
     <span class="desc">将文件从缓存区移除</span>

--- a/zh/branching/index.html
+++ b/zh/branching/index.html
@@ -5,7 +5,7 @@ layout: zh_reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://progit.org/book/ch3-0.html">书</a>
+      <a target="new" href="http://git-scm.com/book/en/Git-Branching">书</a>
     </span>
     分支与合并
   </h2>
@@ -29,8 +29,8 @@ layout: zh_reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-branch.html">文档</a> &nbsp;
-      <a target="new" href="http://progit.org/book/ch3-2.html">书</a>
+      <a target="new" href="http://git-scm.com/docs/git-branch">文档</a> &nbsp;
+      <a target="new" href="http://git-scm.com/book/en/Git-Branching-What-a-Branch-Is">书</a>
     </span>
     <a name="branch">git branch</a>
     <span class="desc">列出、创建与管理工作上下文</span>
@@ -40,8 +40,8 @@ layout: zh_reference
 
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-checkout.html">文档</a> &nbsp;
-      <a target="new" href="http://progit.org/book/ch3-2.html">书</a>
+      <a target="new" href="http://git-scm.com/docs/git-checkout">文档</a> &nbsp;
+      <a target="new" href="http://git-scm.com/book/en/Git-Branching-Basic-Branching-and-Merging">书</a>
     </span>
     <a name="checkout">git checkout</a>
     <span class="desc">切换到新的分支上下文</span>
@@ -59,7 +59,7 @@ layout: zh_reference
     </h4>
 
     <p>没有参数时，<code>git branch</code> 会列出你在本地的分支。你所在的分支的行首会有个星号作标记。
-      如果你开启了<a href="http://progit.org/book/ch7-1.html#colors_in_git">彩色模式</a>，当前分支会用绿色显示。
+      如果你开启了<a href="http://git-scm.com/book/en/Customizing-Git-Git-Configuration#Colors-in-Git">彩色模式</a>，当前分支会用绿色显示。
     </p>
 
 <pre>
@@ -199,8 +199,8 @@ Deleted branch testing (was 78b2670).
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-merge.html">docs</a> &nbsp;
-      <a target="new" href="http://progit.org/book/ch3-2.html#basic_merging">book</a>
+      <a target="new" href="http://git-scm.com/docs/git-merge">docs</a> &nbsp;
+      <a target="new" href="http://git-scm.com/book/en/Git-Branching-Basic-Branching-and-Merging#Basic-Merging">book</a>
     </span>
     <a name="merge">git merge</a>
     <span class="desc">将分支合并到你的当前分支</span>
@@ -380,7 +380,7 @@ nearly every programming language.
 
     <p>你可以看到，Git 在产生合并冲突的地方插入了标准的与 Subversion 很像的合并冲突标记。
       轮到我们去解决这些冲突了。在这里我们就手动把它解决。如果你要 Git 打开一个图形化的合并工具，
-      可以看看 <a href="http://www.kernel.org/pub/software/scm/git/docs/git-mergetool.html">git 合并工具</a>
+      可以看看 <a href="http://git-scm.com/docs/git-mergetool">git 合并工具</a>
       （比如 kdiff3、emerge、p4merge 等）。
     </p>
 
@@ -428,8 +428,8 @@ M  README
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">文档</a> &nbsp;
-      <a target="new" href="http://progit.org/book/ch6-1.html#commit_ranges">书</a>
+      <a target="new" href="http://git-scm.com/docs/git-log">文档</a> &nbsp;
+      <a target="new" href="http://git-scm.com/book/en/Git-Tools-Revision-Selection#Commit-Ranges">书</a>
     </span>
     <a name="log">git log</a>
     <span class="desc">显示一个分支中提交的更改记录</span>
@@ -619,8 +619,8 @@ ab5ab4c added erlang
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-tag.html">文档</a> &nbsp;
-      <a target="new" href="http://progit.org/book/ch2-6.html">书</a>
+      <a target="new" href="http://git-scm.com/docs/git-tag">文档</a> &nbsp;
+      <a target="new" href="http://git-scm.com/book/en/Git-Basics-Tagging">书</a>
     </span>
     <a name="tag">git tag</a>
     <span class="desc">给历史记录中的某个重要的一点打上标签</span>

--- a/zh/creating/index.html
+++ b/zh/creating/index.html
@@ -19,8 +19,8 @@ layout: zh_reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-init.html">文档</a> &nbsp;
-      <a target="new" href="http://progit.org/book/ch2-1.html#initializing_a_repository_in_an_existing_directory">书</a>
+      <a target="new" href="http://git-scm.com/docs/git-init">文档</a> &nbsp;
+      <a target="new" href="http://git-scm.com/book/en/Git-Basics-Getting-a-Git-Repository#Initializing-a-Repository-in-an-Existing-Directory">书</a>
     </span>
     <a name="init">git init</a>
     <span class="desc">将一个目录初始化为 Git 仓库</span>
@@ -67,8 +67,8 @@ Initialized empty Git repository in /opt/konichiwa/.git/
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-clone.html">文档 </a> &nbsp;
-      <a target="new" href="http://progit.org/book/ch2-1.html#cloning_an_existing_repository">书</a>
+      <a target="new" href="http://git-scm.com/docs/git-clone">文档 </a> &nbsp;
+      <a target="new" href="http://git-scm.com/book/en/Git-Basics-Getting-a-Git-Repository#Cloning-an-Existing-Repository">书</a>
     </span>
     <a name="clone">git clone</a>
     <span class="desc">复制一个 Git 仓库，以上下其手</span>

--- a/zh/index.html
+++ b/zh/index.html
@@ -10,7 +10,7 @@ layout: zh_reference
     </p>
     <p>
       每个章节都有到下一个章节的链接，所以本手册也可以当作一个入门指导。
-      每个页面还有一个深度 Git 文档阅读的链接，比如官方的使用手册页面或者 <a href="http://progit.org">《Pro Git》</a>
+      每个页面还有一个深度 Git 文档阅读的链接，比如官方的使用手册页面或者 <a href="http://git-scm.com/book">《Pro Git》</a>
       书中的相关章节，以便于你学习了解更多的 Git 命令。首先，我们要从如何以 Git 的思维方式管理源代码开始。
     </p>
   </div>
@@ -47,7 +47,7 @@ layout: zh_reference
     </p>
 
     <pre>
- $ wget http://sample.com/project.2010-06-01.zip
+ $ wget http://example.com/project.2010-06-01.zip
  $ unzip project.2010-06-01.zip
  $ cp -R project.2010-06-01 project-my-copy
  $ cd project-my-copy

--- a/zh/inspect/index.html
+++ b/zh/inspect/index.html
@@ -5,7 +5,7 @@ layout: zh_reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://progit.org/book/ch2-3.html">书</a>
+      <a target="new" href="http://git-scm.com/book/en/Git-Basics-Viewing-the-Commit-History">书</a>
     </span>
     检查与比较
   </h2>
@@ -26,8 +26,8 @@ layout: zh_reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-log.html">文档</a> &nbsp;
-      <a target="new" href="http://progit.org/book/ch2-3.html">书k</a>
+      <a target="new" href="http://git-scm.com/docs/git-log">文档</a> &nbsp;
+      <a target="new" href="http://git-scm.com/book/en/Git-Basics-Viewing-the-Commit-History#Limiting-Log-Output">书k</a>
     </span>
     <a name="log">git log</a>
     <span class="desc">过滤你的提交历史记录</span>
@@ -293,8 +293,8 @@ Date:   Fri Jun 4 12:58:53 2010 +0200
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://www.kernel.org/pub/software/scm/git/docs/git-diff.html">文档</a> &nbsp;
-      <a target="new" href="http://progit.org/book/ch5-3.html#determining_what_is_introduced">书</a>
+      <a target="new" href="http://git-scm.com/docs/git-diff">文档</a> &nbsp;
+      <a target="new" href="http://git-scm.com/book/en/Distributed-Git-Maintaining-a-Project#Determining-What-Is-Introduced">书</a>
     </span>
     <a name="diff">git diff</a>
     <span class="desc"></span>
@@ -449,4 +449,4 @@ index bb86f00..192151c 100644
 </div>
 
 <p>就是这样了！ 请阅读
-<a href="http://progit.org">《Pro Git》</a> 以获得更多信息。</p>
+<a href="http://git-scm.com/book/">《Pro Git》</a> 以获得更多信息。</p>

--- a/zh/remotes/index.html
+++ b/zh/remotes/index.html
@@ -5,7 +5,7 @@ layout: zh_reference
 <div class="box">
   <h2>
     <span class="docs">
-      <a target="new" href="http://progit.org/book/ch2-5.html">书</a>
+      <a target="new" href="http://git-scm.com/book/en/Git-Basics-Working-with-Remotes">书</a>
     </span>
     分享与更新项目
   </h2>
@@ -39,7 +39,7 @@ layout: zh_reference
   <h2>
     <span class="docs">
       <a target="new" href="http://git-scm.com/docs/git-remote">文档</a> &nbsp;
-      <a target="new" href="http://progit.org/book/ch2-5.html#showing_your_remotes">书</a>
+      <a target="new" href="http://git-scm.com/book/en/Git-Basics-Working-with-Remotes#Showing-Your-Remotes">书</a>
     </span>
     <a name="remote">git remote</a>
     <span class="desc">罗列、添加和删除远端仓库别名</span>
@@ -148,7 +148,7 @@ github	git@github.com:schacon/hw.git (push)
   <h2>
     <span class="docs">
       <a target="new" href="http://git-scm.com/docs/git-fetch">文档</a> &nbsp;
-      <a target="new" href="http://progit.org/book/ch2-5.html#fetching_and_pulling_from_your_remotes">书</a>
+      <a target="new" href="http://git-scm.com/book/en/Git-Basics-Working-with-Remotes#Fetching-and-Pulling-from-Your-Remotes">书</a>
     </span>
     <a name="fetch">git fetch</a>
     <span class="desc">从远端仓库下载新分支与数据</span>
@@ -159,7 +159,7 @@ github	git@github.com:schacon/hw.git (push)
   <h2>
     <span class="docs">
       <a target="new" href="http://git-scm.com/docs/git-pull">文档</a> &nbsp;
-      <a target="new" href="http://progit.org/book/">书</a>
+      <a target="new" href="http://git-scm.com/book/en/Git-Basics-Working-with-Remotes#Fetching-and-Pulling-from-Your-Remotes">书</a>
     </span>
     <a name="pull">git pull</a>
     <span class="desc">从远端仓库提取数据并尝试合并到当前分支</span>
@@ -234,7 +234,7 @@ From github.com:schacon/hw
   <h2>
     <span class="docs">
       <a target="new" href="http://git-scm.com/docs/git-push">文档</a> &nbsp;
-      <a target="new" href="http://progit.org/book/ch2-5.html#pushing_to_your_remotes">书</a>
+      <a target="new" href="http://git-scm.com/book/en/Git-Basics-Working-with-Remotes#Pushing-to-Your-Remotes">书</a>
     </span>
     <a name="push">git push</a>
     <span class="desc">推送你的新分支与数据到某个远端仓库</span>


### PR DESCRIPTION
Includes changing the sample.com domain used in the example to IANA example.com as the former points to perfume.

And since all the GitHub links are on SSL, updated those in the header.

Relate to issue #42 on updating progit.org links
