### PR TITLE
fix position of 'git branch -v'

### DIFF
--- a/branching/index.html
+++ b/branching/index.html
@@ -146,6 +146,21 @@ README   hello.rb more.txt test.txt
 </pre>
 
     <h4>
+      git branch -v
+      <small>see the last commit on each branch</small>
+    </h4>
+
+    <p>If we want to see last commits on each branch 
+    we can run <code>git branch -v</code> to see them.</p>
+
+<pre>
+<b>$ git branch -v</b>
+* <span class="green">master</span>      54b417d fix javascript issue
+  development 74c111d modify component.json file
+  testing     62a557a update test scripts
+</pre>
+
+    <h4>
       git checkout -b (branchname)
       <small>create and immediately switch to a branch</small>
     </h4>
@@ -321,21 +336,6 @@ HelloWorld.hello
     <p>So first we're going to create a new branch named 'change_class' and
     switch to it so your class renaming changes are isolated. We're going to
     change each instance of 'HelloWorld' to 'HiWorld'.</p>
-
-    <h4>
-      git branch -v
-      <small>see the last commit on each branch</small>
-    </h4>
-
-    <p>If we want to see last commits on each branch 
-    we can run <code>git branch -v</code> to see them.</p>
-
-<pre>
-<b>$ git branch -v</b>
-* <span class="green">master</span>      54b417d fix javascript issue
-  development 74c111d modify component.json file
-  testing     62a557a update test scripts
-</pre>
 
 <pre>
 <b>$ git checkout -b change_class</b>


### PR DESCRIPTION
@randomecho @matthewmccullough  It seems like something went wrong with Github's browser editor tool (or maybe it was me :smiley:)

This commit should put `git branch -v` in its proper place.

Thanks
