### PR TITLE
Fixed minor grammar error: Changed when to once

### DIFF
--- a/basic/index.html
+++ b/basic/index.html
@@ -605,7 +605,7 @@ Further paragraphs come after blank lines.
 
   <div class="block">
     <p><code>git reset</code> is probably the most confusing command written
-    by humans, but it can be very useful when you get the hang of it.
+    by humans, but it can be very useful once you get the hang of it.
     There are three specific invocations of it that are generally
     helpful.
     </p>


### PR DESCRIPTION
"Once" is used once an action is complete, while "When" is used when an action begins.
