### PR TITLE
Remove background from #branding in css/layout.css

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -205,7 +205,6 @@ h1 a {
 	padding:8px;
 	margin-bottom:0;
 	color: #333;
-	background: #fff;
 }
 
 


### PR DESCRIPTION
I've removed the background from `#branding` in order to avoid its overlapping with the black top border

![gitref](https://cloud.githubusercontent.com/assets/2000050/5381146/c213fe08-8085-11e4-8eac-1b619f35f947.png)
