### PR TITLE
Fixed an incorrect statement in the 'git reset' section.

### DIFF
--- a/basic/index.html
+++ b/basic/index.html
@@ -761,9 +761,9 @@ nothing to commit (working directory clean)
 
     <p class="nutshell">
     <strong>In a nutshell</strong>,
-    you run <code>git reset HEAD</code> to undo the last commit, unstage
-    files that you previously ran <code>git add</code> on and wish to not
-    include in the next commit snapshot</p>
+    you run <code>git reset --hard HEAD</code> to undo all working changes since
+    the last commit, unstage files that you previously ran <code>git add</code>
+    on and wish to not include in the next commit snapshot</p>
 
   </div>
 </div>


### PR DESCRIPTION
This fixes the following misstatement in the **git reset** section: "[...] you run `git reset HEAD` to undo the last commit". Also, it appears the `--hard` option was omitted from the command, since this paragraph is part of the discussion of `--hard`.
