### PR TITLE
Update menu structure to reflect page structure

### DIFF
--- a/_layouts/reference.html
+++ b/_layouts/reference.html
@@ -69,9 +69,9 @@
           <div class="block">
             <h3><a href="/remotes">Sharing and Updating Projects</a></h3>
             <ul>
+              <li><a href="/remotes/#remote">remote</a></li>
               <li><a href="/remotes/#fetch">fetch, pull</a></li>
               <li><a href="/remotes/#push">push</a></li>
-              <li><a href="/remotes/#remote">remote</a></li>
             </ul>
           </div>
 


### PR DESCRIPTION
This just affects the page “Sharing and Updating Projects.” The menus of all other pages are in sync.
