### PR TITLE
Remove CNAME for deprecated URL

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-gitref.org


### PR DESCRIPTION
This PR removes references to gitref.org which is no longer available.

@brntbeer you seem to have access to this repo -- would you mind 🚢 ing this? You may also have to update the URL on the repo description. 

Related conversation: https://github.com/github/services-training/issues/460