### PR TITLE
Site baseurl for proper asset paths

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+baseurl: /git-reference

--- a/_layouts/reference.html
+++ b/_layouts/reference.html
@@ -23,9 +23,9 @@
 
 			<div class="grid_12">
 				<ul id="menu">
-					<li><a id="menu_home" href="index.html">Reference</a></li>
+					<li><a id="menu_home" href="{{ site.baseurl }}/index.html">Reference</a></li>
           <!-- <li><a id="menu_cookbook" href="/cookbook.html">Cookbook</a></li> -->
-					<li><a id="menu_about" href="about.html">About</a></li>
+					<li><a id="menu_about" href="{{ site.baseurl }}/about.html">About</a></li>
 					<li>&#167;</li>
 					<li><a href="https://github.com/git/git-reference">Site Source</a></li>
         </ul>
@@ -35,51 +35,51 @@
 
 			<div class="grid_2" id="reflist">
           <div class="block">
-            <h3><a href="creating">Getting and Creating Projects</a></h3>
+            <h3><a href="{{ site.baseurl }}/creating">Getting and Creating Projects</a></h3>
             <ul>
-              <li><a href="creating/#init">init</a></li>
-              <li><a href="creating/#clone">clone</a></li>
+              <li><a href="{{ site.baseurl }}/creating/#init">init</a></li>
+              <li><a href="{{ site.baseurl }}/creating/#clone">clone</a></li>
             </ul>
 					</div>
 
           <div class="block">
-            <h3><a href="basic">Basic Snapshotting</a></h3>
+            <h3><a href="{{ site.baseurl }}/basic">Basic Snapshotting</a></h3>
             <ul>
-              <li><a href="basic/#add">add</a></li>
-              <li><a href="basic/#status">status</a></li>
-              <li><a href="basic/#diff">diff</a></li>
-              <li><a href="basic/#commit">commit</a></li>
-              <li><a href="basic/#reset">reset</a></li>
-              <li><a href="basic/#rm-mv">rm, mv</a></li>
-              <li><a href="basic/#stash">stash</a></li>
+              <li><a href="{{ site.baseurl }}/basic/#add">add</a></li>
+              <li><a href="{{ site.baseurl }}/basic/#status">status</a></li>
+              <li><a href="{{ site.baseurl }}/basic/#diff">diff</a></li>
+              <li><a href="{{ site.baseurl }}/basic/#commit">commit</a></li>
+              <li><a href="{{ site.baseurl }}/basic/#reset">reset</a></li>
+              <li><a href="{{ site.baseurl }}/basic/#rm-mv">rm, mv</a></li>
+              <li><a href="{{ site.baseurl }}/basic/#stash">stash</a></li>
             </ul>
           </div>
 
           <div class="block">
-            <h3><a href="branching">Branching and Merging</a></h3>
+            <h3><a href="{{ site.baseurl }}/branching">Branching and Merging</a></h3>
             <ul>
-              <li><a href="branching/#branch">branch</a></li>
-              <li><a href="branching/#branch">checkout</a></li>
-              <li><a href="branching/#merge">merge</a></li>
-              <li><a href="branching/#log">log</a></li>
-              <li><a href="branching/#tag">tag</a></li>
+              <li><a href="{{ site.baseurl }}/branching/#branch">branch</a></li>
+              <li><a href="{{ site.baseurl }}/branching/#branch">checkout</a></li>
+              <li><a href="{{ site.baseurl }}/branching/#merge">merge</a></li>
+              <li><a href="{{ site.baseurl }}/branching/#log">log</a></li>
+              <li><a href="{{ site.baseurl }}/branching/#tag">tag</a></li>
             </ul>
           </div>
 
           <div class="block">
-            <h3><a href="remotes">Sharing and Updating Projects</a></h3>
+            <h3><a href="{{ site.baseurl }}/remotes">Sharing and Updating Projects</a></h3>
             <ul>
-              <li><a href="remotes/#remote">remote</a></li>
-              <li><a href="remotes/#fetch">fetch, pull</a></li>
-              <li><a href="remotes/#push">push</a></li>
+              <li><a href="{{ site.baseurl }}/remotes/#remote">remote</a></li>
+              <li><a href="{{ site.baseurl }}/remotes/#fetch">fetch, pull</a></li>
+              <li><a href="{{ site.baseurl }}/remotes/#push">push</a></li>
             </ul>
           </div>
 
           <div class="block">
-            <h3><a href="inspect">Inspection and Comparison</a></h3>
+            <h3><a href="{{ site.baseurl }}/inspect">Inspection and Comparison</a></h3>
             <ul>
-              <li><a href="inspect/#log">log</a></li>
-              <li><a href="inspect/#diff">diff</a></li>
+              <li><a href="{{ site.baseurl }}/inspect/#log">log</a></li>
+              <li><a href="{{ site.baseurl }}/inspect/#diff">diff</a></li>
             </ul>
           </div>
 

--- a/_layouts/reference.html
+++ b/_layouts/reference.html
@@ -3,16 +3,16 @@
 	<head>
 		<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 		<title>Git Reference</title>
-		<link rel="stylesheet" type="text/css" href="css/reset.css" media="screen" />
-		<link rel="stylesheet" type="text/css" href="css/text.css" media="screen" />
-		<link rel="stylesheet" type="text/css" href="css/grid.css" media="screen" />
-		<link rel="stylesheet" type="text/css" href="css/layout.css" media="screen" />
-		<link rel="stylesheet" type="text/css" href="css/nav.css" media="screen" />
-		<!--[if IE 6]><link rel="stylesheet" type="text/css" href="css/ie6.css" media="screen" /><![endif]-->
-		<!--[if IE 7]><link rel="stylesheet" type="text/css" href="css/ie.css" media="screen" /><![endif]-->
-		<script type="text/javascript" src="js/jquery-1.4.1.min.js"></script>
-		<script type="text/javascript" src="js/jquery-ui.min.js"></script>
-		<script type="text/javascript" src="js/action.js"></script>
+		<link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/css/reset.css" media="screen" />
+		<link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/css/text.css" media="screen" />
+		<link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/css/grid.css" media="screen" />
+		<link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/css/layout.css" media="screen" />
+		<link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/css/nav.css" media="screen" />
+		<!--[if IE 6]><link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/css/ie6.css" media="screen" /><![endif]-->
+		<!--[if IE 7]><link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/css/ie.css" media="screen" /><![endif]-->
+		<script type="text/javascript" src="{{ site.baseurl }}/js/jquery-1.4.1.min.js"></script>
+		<script type="text/javascript" src="{{ site.baseurl }}/js/jquery-ui.min.js"></script>
+		<script type="text/javascript" src="{{ site.baseurl }}/js/action.js"></script>
 	</head>
 	<body>
     <div class="container_12">

--- a/_layouts/zh_reference.html
+++ b/_layouts/zh_reference.html
@@ -23,9 +23,9 @@
 
 			<div class="grid_12">
 				<ul id="menu">
-					<li><a id="menu_home" href="zh/index.html">参考手册</a></li>
+					<li><a id="menu_home" href="{{ site.baseurl }}/zh/index.html">参考手册</a></li>
           <!-- <li><a id="menu_cookbook" href="zh/cookbook.html">Cookbook</a></li> -->
-					<li><a id="menu_about" href="zh/about.html">关于</a></li>
+					<li><a id="menu_about" href="{{ site.baseurl }}/zh/about.html">关于</a></li>
 					<li>&#167;</li>
 					<li><a href="https://github.com/git/git-reference">网站源码</a></li>
         </ul>
@@ -35,50 +35,50 @@
 
 			<div class="grid_2" id="reflist">
           <div class="block">
-            <h3><a href="zh/creating">获取与创建项目</a></h3>
+            <h3><a href="{{ site.baseurl }}/zh/creating">获取与创建项目</a></h3>
             <ul>
-              <li><a href="zh/creating/#init">init</a></li>
-              <li><a href="zh/creating/#clone">clone</a></li>
+              <li><a href="{{ site.baseurl }}/zh/creating/#init">init</a></li>
+              <li><a href="{{ site.baseurl }}/zh/creating/#clone">clone</a></li>
             </ul>
 					</div>
 
           <div class="block">
-            <h3><a href="zh/basic">基本的快照</a></h3>
+            <h3><a href="{{ site.baseurl }}/zh/basic">基本的快照</a></h3>
             <ul>
-              <li><a href="zh/basic/#add">add</a></li>
-              <li><a href="zh/basic/#status">status</a></li>
-              <li><a href="zh/basic/#diff">diff</a></li>
-              <li><a href="zh/basic/#commit">commit</a></li>
-              <li><a href="zh/basic/#reset">reset</a></li>
-              <li><a href="zh/basic/#rm-mv">rm, mv</a></li>
+              <li><a href="{{ site.baseurl }}/zh/basic/#add">add</a></li>
+              <li><a href="{{ site.baseurl }}/zh/basic/#status">status</a></li>
+              <li><a href="{{ site.baseurl }}/zh/basic/#diff">diff</a></li>
+              <li><a href="{{ site.baseurl }}/zh/basic/#commit">commit</a></li>
+              <li><a href="{{ site.baseurl }}/zh/basic/#reset">reset</a></li>
+              <li><a href="{{ site.baseurl }}/zh/basic/#rm-mv">rm, mv</a></li>
             </ul>
           </div>
 
           <div class="block">
-            <h3><a href="zh/branching">分支与合并</a></h3>
+            <h3><a href="{{ site.baseurl }}/zh/branching">分支与合并</a></h3>
             <ul>
-              <li><a href="zh/branching/#branch">branch</a></li>
-              <li><a href="zh/branching/#branch">checkout</a></li>
-              <li><a href="zh/branching/#merge">merge</a></li>
-              <li><a href="zh/branching/#log">log</a></li>
-              <li><a href="zh/branching/#tag">tag</a></li>
+              <li><a href="{{ site.baseurl }}/zh/branching/#branch">branch</a></li>
+              <li><a href="{{ site.baseurl }}/zh/branching/#branch">checkout</a></li>
+              <li><a href="{{ site.baseurl }}/zh/branching/#merge">merge</a></li>
+              <li><a href="{{ site.baseurl }}/zh/branching/#log">log</a></li>
+              <li><a href="{{ site.baseurl }}/zh/branching/#tag">tag</a></li>
             </ul>
           </div>
 
           <div class="block">
-            <h3><a href="zh/remotes">分享与更新项目</a></h3>
+            <h3><a href="{{ site.baseurl }}/zh/remotes">分享与更新项目</a></h3>
             <ul>
-              <li><a href="zh/remotes/#fetch">fetch, pull</a></li>
-              <li><a href="zh/remotes/#push">push</a></li>
-              <li><a href="zh/remotes/#remote">remote</a></li>
+              <li><a href="{{ site.baseurl }}/zh/remotes/#fetch">fetch, pull</a></li>
+              <li><a href="{{ site.baseurl }}/zh/remotes/#push">push</a></li>
+              <li><a href="{{ site.baseurl }}/zh/remotes/#remote">remote</a></li>
             </ul>
           </div>
 
           <div class="block">
-            <h3><a href="zh/inspect">检查与比较</a></h3>
+            <h3><a href="{{ site.baseurl }}/zh/inspect">检查与比较</a></h3>
             <ul>
-              <li><a href="zh/inspect/#log">log</a></li>
-              <li><a href="zh/inspect/#diff">diff</a></li>
+              <li><a href="{{ site.baseurl }}/zh/inspect/#log">log</a></li>
+              <li><a href="{{ site.baseurl }}/zh/inspect/#diff">diff</a></li>
             </ul>
           </div>
 

--- a/_layouts/zh_reference.html
+++ b/_layouts/zh_reference.html
@@ -3,16 +3,16 @@
 	<head>
 		<meta charset="utf-8" />
 		<title>Git 参考手册</title>
-		<link rel="stylesheet" type="text/css" href="css/reset.css" media="screen" />
-		<link rel="stylesheet" type="text/css" href="css/text.css" media="screen" />
-		<link rel="stylesheet" type="text/css" href="css/grid.css" media="screen" />
-		<link rel="stylesheet" type="text/css" href="css/layout.css" media="screen" />
-		<link rel="stylesheet" type="text/css" href="css/nav.css" media="screen" />
-		<!--[if IE 6]><link rel="stylesheet" type="text/css" href="css/ie6.css" media="screen" /><![endif]-->
-		<!--[if IE 7]><link rel="stylesheet" type="text/css" href="css/ie.css" media="screen" /><![endif]-->
-		<script type="text/javascript" src="js/jquery-1.4.1.min.js"></script>
-		<script type="text/javascript" src="js/jquery-ui.min.js"></script>
-		<script type="text/javascript" src="js/action.js"></script>
+		<link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/css/reset.css" media="screen" />
+		<link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/css/text.css" media="screen" />
+		<link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/css/grid.css" media="screen" />
+		<link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/css/layout.css" media="screen" />
+		<link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/css/nav.css" media="screen" />
+		<!--[if IE 6]><link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/css/ie6.css" media="screen" /><![endif]-->
+		<!--[if IE 7]><link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/css/ie.css" media="screen" /><![endif]-->
+		<script type="text/javascript" src="{{ site.baseurl }}/js/jquery-1.4.1.min.js"></script>
+		<script type="text/javascript" src="{{ site.baseurl }}/js/jquery-ui.min.js"></script>
+		<script type="text/javascript" src="{{ site.baseurl }}/js/action.js"></script>
 	</head>
 	<body>
     <div class="container_12">

--- a/basic/index.html
+++ b/basic/index.html
@@ -730,7 +730,7 @@ nothing to commit (working directory clean)
        dangerous option and is not working directory safe. Any changes not committed will
        be lost.
     </p>
-    
+
 <pre>
 <b>$ git status</b>
 # On branch master
@@ -970,5 +970,4 @@ Dropped stash@{1} (0b1478540189f30fef9804684673907c65865d8f)
   </div>
 </div>
 
-<p><a class="page-button next-page" href="/branching">On to Branching and Merging &#187;</a></p>
-
+<p><a class="page-button next-page" href="{{ site.baseurl }}/branching">On to Branching and Merging &#187;</a></p>

--- a/branching/index.html
+++ b/branching/index.html
@@ -150,7 +150,7 @@ README   hello.rb more.txt test.txt
       <small>see the last commit on each branch</small>
     </h4>
 
-    <p>If we want to see last commits on each branch 
+    <p>If we want to see last commits on each branch
     we can run <code>git branch -v</code> to see them.</p>
 
 <pre>
@@ -860,5 +860,4 @@ From git://github.com:example-user/example-repo
   </div>
 </div>
 
-<p><a class="page-button next-page" href="/remotes">On to Sharing and Updating Projects &#187;</a></p>
-
+<p><a class="page-button next-page" href="{{ site.baseurl }}/remotes">On to Sharing and Updating Projects &#187;</a></p>

--- a/creating/index.html
+++ b/creating/index.html
@@ -139,4 +139,4 @@ config      index       <span class="blue">objects</span>
   </div>
 </div>
 
-<p><a class="page-button next-page" href="/basic">On to Basic Snapshotting &#187;</a></p>
+<p><a class="page-button next-page" href="{{ site.baseurl }}/basic">On to Basic Snapshotting &#187;</a></p>

--- a/index.html
+++ b/index.html
@@ -109,4 +109,4 @@ layout: reference
   </div>
 </div>
 
-<p><a class="page-button next-page" href="/creating">On to Getting and Creating Projects &#187;</a></p>
+<p><a class="page-button next-page" href="{{ site.baseurl }}/creating">On to Getting and Creating Projects &#187;</a></p>

--- a/remotes/index.html
+++ b/remotes/index.html
@@ -151,7 +151,7 @@ github	git@github.com:schacon/hw.git (push)
       <small>rename remote aliases</small>
     </h4>
 
-    <p>If you want to rename remote aliases without having to delete them and add them again 
+    <p>If you want to rename remote aliases without having to delete them and add them again
     you can do that by running <code>git remote rename [old-alias] [new-alias]</code>. This will
     allow you to modify the current name of the remote.</p>
 
@@ -437,4 +437,4 @@ fast-forwards' section of 'git push --help' for details.
   </div>
 </div>
 
-<p><a class="page-button next-page" href="/inspect">On to Inspection and Comparison &#187;</a></p>
+<p><a class="page-button next-page" href="{{ site.baseurl }}/inspect">On to Inspection and Comparison &#187;</a></p>

--- a/zh/basic/index.html
+++ b/zh/basic/index.html
@@ -641,5 +641,4 @@ M hello.rb
   </div>
 </div>
 
-<p><a href="/zh/branching">到 分支与合并 &#187;</a></p>
-
+<p><a href="{{ site.baseurl }}/zh/branching">到 分支与合并 &#187;</a></p>

--- a/zh/branching/index.html
+++ b/zh/branching/index.html
@@ -696,5 +696,4 @@ ab5ab4c added erlang
   </div>
 </div>
 
-<p><a href="/zh/remotes">到 分享与更新项目 &#187;</a></p>
-
+<p><a href="{{ site.baseurl }}/zh/remotes">到 分享与更新项目 &#187;</a></p>

--- a/zh/creating/index.html
+++ b/zh/creating/index.html
@@ -120,4 +120,4 @@ config      index       <span class="blue">objects</span>
   </div>
 </div>
 
-<p><a href="/zh/basic">接下来：基本快照 &#187;</a></p>
+<p><a href="{{ site.baseurl }}/zh/basic">接下来：基本快照 &#187;</a></p>

--- a/zh/index.html
+++ b/zh/index.html
@@ -79,4 +79,4 @@ layout: zh_reference
   </div>
 </div>
 
-<p><a href="/zh/creating">接下来：获取与创建项目&#187;</a></p>
+<p><a href="{{ site.baseurl }}/zh/creating">接下来：获取与创建项目&#187;</a></p>

--- a/zh/remotes/index.html
+++ b/zh/remotes/index.html
@@ -318,4 +318,4 @@ fast-forwards' section of 'git push --help' for details.
   </div>
 </div>
 
-<p><a href="/zh/inspect">到 检查与比较&#187;</a></p>
+<p><a href="{{ site.baseurl }}/zh/inspect">到 检查与比较&#187;</a></p>


### PR DESCRIPTION
working off of work done in #113, i also created a `_config.yml` to have a site.baseurl that i added to most every link.

I know there's a way to do this easier, but this at least fixes link.

There is one existing issue that i *think* i can reproduce from time to time on the `zh/` site, where the existing URL stays as if it's the `site.baseurl`. could approach that if we see more errors.